### PR TITLE
Add Symantec VEGA Log Server, remove Certly.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 *PHP command line tool to generate Certificate Transparency information*
 
 This script is tuned to work with [Let's Encrypt](https://letsencrypt.org/) certificates so it submits the certificate to:
-* log.certly.io
 * ct.googleapis.com/aviator
 * ct.googleapis.com/pilot
 * ct.googleapis.com/rocketeer

--- a/cts-submit.php
+++ b/cts-submit.php
@@ -17,7 +17,6 @@
 	curl_setopt($curl_handle, CURLOPT_SSL_VERIFYPEER, 1);
 
 	$servers=array();
-	$servers[]="log.certly.io";
 	$servers[]="ct.googleapis.com/aviator";
 	$servers[]="ct.googleapis.com/pilot";
 	$servers[]="ct.googleapis.com/rocketeer";
@@ -26,6 +25,7 @@
 	$servers[]="ct1.digicert-ct.com/log";
 	$servers[]="ct.izenpe.com";
 	$servers[]="ct.ws.symantec.com";
+	$servers[]="vega.ws.symantec.com";
 	*/
 	$servers[]="ctlog.api.venafi.com";
 


### PR DESCRIPTION
Certly.io: Removed, closes https://github.com/jbvignaud/cts-submit/issues/8

VEGA: For now disabled. I have not tested whether it accepts LE certs, but I doubt it does as the other Symantec log does not accept them either. (according to that description)
